### PR TITLE
Change how working-directory works

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Release Ruby Gem to GitHub Packages
-This action builds the gems for all `.gemspec` files in the projects root and uploads them to [GitHub Packages](https://github.com/features/packages).
+This action builds the gems for all `.gemspec` files in the projects root and uploads them to [GitHub Packages](https://github.com/features/packages) (or optionally specify a subdirectory to build from).
 
 ## Usage
 Example minimal workflow using this action:
@@ -26,10 +26,11 @@ See example project using this action at [https://github.com/jstastny/testgem](h
 
 ## Inputs
 
-| Name | Description |
-| -----| ------------|
-| `token` | GitHub token that has write access to Packages. You can use `secrets.GITHUB_TOKEN` |
-| `owner` | Name of the user or organization account that owns the repository containing your project |
+| Name                | Description                                                                                     |
+| ------------------- | ----------------------------------------------------------------------------------------------- |
+| `token`             | GitHub token that has write access to Packages. You can use `secrets.GITHUB_TOKEN`              |
+| `owner`             | Name of the user or organization account that owns the repository containing your project       |
+| `working-directory` | Optional parameter of the directory where you wish to build your gemspecs in (defaults to root) |
 
 ## Versioning your gem
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,9 @@ touch ~/.gem/credentials
 chmod 600 ~/.gem/credentials
 echo ":github: Bearer ${GITHUB_TOKEN}" >> ~/.gem/credentials
 
+cd "${WORKING_DIRECTORY:-.}"
+
 echo "Building the gem"
-gem build ${WORKING_DIRECTORY:-.}/*.gemspec
+gem build *.gemspec
 echo "Pushing the built gem to GitHub Package Registry"
 gem push --key github --host "https://rubygems.pkg.github.com/${OWNER}" ./*.gem


### PR DESCRIPTION
This is in reference to #4 where we cd into the working directory prior to building the gemspec, which seems to allow the gems to work better if they exist in a subdirectory. Without this, I was noticing that I could not require the gems that were being built.

Thanks!