### PR TITLE
Support publishing multiple gems in the same directory

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,6 @@ echo ":github: Bearer ${GITHUB_TOKEN}" >> ~/.gem/credentials
 cd "${WORKING_DIRECTORY:-.}"
 
 echo "Building the gem"
-gem build *.gemspec
+find . -name '*.gemspec' -exec gem build {} \;
 echo "Pushing the built gem to GitHub Package Registry"
-gem push --key github --host "https://rubygems.pkg.github.com/${OWNER}" ./*.gem
+find . -name '*.gem' -exec gem push --key github --host "https://rubygems.pkg.github.com/${OWNER}" {} \;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,6 @@ echo ":github: Bearer ${GITHUB_TOKEN}" >> ~/.gem/credentials
 cd "${WORKING_DIRECTORY:-.}"
 
 echo "Building the gem"
-find . -name '*.gemspec' -exec gem build {} \;
+find . -name '*.gemspec' -maxdepth 1 -exec gem build {} \;
 echo "Pushing the built gem to GitHub Package Registry"
-find . -name '*.gem' -exec gem push --key github --host "https://rubygems.pkg.github.com/${OWNER}" {} \;
+find . -name '*.gem' -maxdepth 1 -exec gem push --key github --host "https://rubygems.pkg.github.com/${OWNER}" {} \;


### PR DESCRIPTION
We ran into an issue when we had multiple `.gemspec` files in the same directory. `gem build` only supports one entry at a time. This PR updates the code with `find`, so for every `.gemspec` it will execute the build command.

Github Packages allows (since recently?) to push multiple gems from the same GitHub repository:
https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-rubygems-registry#publishing-multiple-packages-to-the-same-repository