### PR TITLE
Fix for Git v2.35.2 (unsafe repository)

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,9 @@
 #!/bin/sh -l
 
+cd "${GITHUB_WORKSPACE}" || exit 1
+
+git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
 GITHUB_TOKEN=$1
 OWNER=$2
 WORKING_DIRECTORY=$3


### PR DESCRIPTION
Since the fix for https://github.blog/2022-04-12-git-security-vulnerability-announced/ the gems that were published by this action were empty.

The logs showed us this:

```txt
Building the gem
fatal: unsafe repository ('/github/workspace' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
WARNING:  licenses is empty, but is recommended.  Use a license identifier from
http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
WARNING:  no files specified
```

I cheated and copied the fix from https://github.com/crowdin/github-action/pull/115

With this patch it works again.