### PR TITLE
Fixed: Issue where the L argument is not available on Alpine Linux's xargs command.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,4 +22,4 @@ cd "${WORKING_DIRECTORY:-.}"
 echo "Building the gem"
 find . -name '*.gemspec' -maxdepth 1 -exec gem build {} \;
 echo "Pushing the built gem to GitHub Package Registry"
-find . -name '*.gem' -maxdepth 1 -print0 | xargs -0L1 gem push --key github --host "https://rubygems.pkg.github.com/${OWNER}"
+find . -name '*.gem' -maxdepth 1 -print0 | xargs -0 gem push --key github --host "https://rubygems.pkg.github.com/${OWNER}"


### PR DESCRIPTION
Fixes #12, an issue where the `L` xargs flag is not supported on Alpine Linux.

I tested my branch both in the failing use case and successful use case.