### PR TITLE
Peg version of bundler to latest version compatible with ruby 2.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:2.7-alpine
 RUN apk add --no-cache git
 
 RUN set -x \
-  && gem install bundler keycutter
+  && gem install bundler:2.4.22 keycutter
 
 COPY LICENSE README.md /
 


### PR DESCRIPTION
Noticed this morning that bundler 2.5.0 was released, which is incompatible with ruby 2.7. It breaks the Dockerfile.